### PR TITLE
Remove extra slash in the API URL composition

### DIFF
--- a/voto/src/main/java/com/addhen/voto/sdk/BaseApiBuilder.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/BaseApiBuilder.java
@@ -94,7 +94,7 @@ public abstract class BaseApiBuilder<B, A> {
     }
 
     protected String getBaseUrl() {
-        return Constants.VotoEndpoints.VOTO_API_ENDPOINT + "/" + mApiVersion + "/";
+        return Constants.VotoEndpoints.VOTO_API_ENDPOINT + mApiVersion + "/";
     }
 
     protected void initDefaultRetrofit() {


### PR DESCRIPTION
Fixes #17 

This `PR` makes the following changes:
- 
- Remove an extra slash when composing the API

Ping @eyedol