### PR TITLE
Download audio file

### DIFF
--- a/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
+++ b/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
@@ -19,6 +19,7 @@ import com.addhen.voto.sdk.BaseApiBuilder;
 import com.addhen.voto.sdk.BaseVotoApiClient;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -34,6 +35,7 @@ import com.addhen.voto.sdk.util.StringUtils;
 import java.io.IOException;
 import java.util.Map;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Retrofit;
@@ -107,6 +109,15 @@ public class AsyncVotoApiClient extends BaseVotoApiClient {
             AudioFileExtension fileExtension, Map<String, String> optionalFields,
             Callback<UploadAudioFileResponse> callback)
             throws IOException {
+
+        if (StringUtils.isEmpty(description)) {
+            throw new IllegalArgumentException("description is required.");
+        }
+
+        if ((fileExtension == null) || (StringUtils.isEmpty(fileExtension.name()))) {
+            throw new IllegalArgumentException("fileExtension is required.");
+        }
+
         Call<UploadAudioFileResponse> call = mAsyncVotoService
                 .uploadAudioFileContent(description, fileExtension, optionalFields);
         call.enqueue(callback);
@@ -129,8 +140,29 @@ public class AsyncVotoApiClient extends BaseVotoApiClient {
     public void updateAudioFileContent(Long id,
             AudioFileExtension fileExtension, Map<String, String> optionalFields,
             Callback<UploadAudioFileResponse> callback) {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null.");
+        }
+
+        if ((fileExtension == null) || (StringUtils.isEmpty(fileExtension.name()))) {
+            throw new IllegalArgumentException("fileExtension is required.");
+        }
+
         Call<UploadAudioFileResponse> call = mAsyncVotoService
                 .updateAudioFileContent(id, fileExtension, optionalFields);
+        call.enqueue(callback);
+    }
+
+    public void downloadAudioFile(Long id, AudioFileFormat format, Callback<ResponseBody> callback) {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null.");
+        }
+
+        if ((format == null) || (StringUtils.isEmpty(format.name()))) {
+            throw new IllegalArgumentException("format is required.");
+        }
+
+        Call<ResponseBody> call = mAsyncVotoService.downloadAudioFile(id, format);
         call.enqueue(callback);
     }
 

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
@@ -19,6 +19,7 @@ import com.addhen.voto.sdk.BaseApiBuilder;
 import com.addhen.voto.sdk.BaseVotoApiClient;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -33,6 +34,7 @@ import com.addhen.voto.sdk.util.StringUtils;
 
 import java.util.Map;
 
+import okhttp3.ResponseBody;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.http.QueryMap;
@@ -133,6 +135,19 @@ public class RxJavaVotoApiClient extends BaseVotoApiClient {
             AudioFileExtension fileExtension, Map<String, String> optionalFields) {
         Observable<UploadAudioFileResponse> observable = mRxJavaVotoService
                 .updateAudioFileContent(id, fileExtension, optionalFields);
+        return observable;
+    }
+
+    public Observable<ResponseBody> downloadAudioFile(Long id, AudioFileFormat format) {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null.");
+        }
+
+        if ((format == null) || (StringUtils.isEmpty(format.name()))) {
+            throw new IllegalArgumentException("format is required.");
+        }
+
+        Observable<ResponseBody> observable = mRxJavaVotoService.downloadAudioFile(id, format);
         return observable;
     }
 

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/service/RxJavaVotoService.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/service/RxJavaVotoService.java
@@ -19,6 +19,7 @@ package com.addhen.voto.sdk.rxjava.service;
 import com.addhen.voto.sdk.Constants;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -31,6 +32,7 @@ import com.addhen.voto.sdk.model.subscribers.SubscriberDetailsResponse;
 
 import java.util.Map;
 
+import okhttp3.ResponseBody;
 import retrofit2.http.DELETE;
 import retrofit2.http.Field;
 import retrofit2.http.FieldMap;
@@ -41,6 +43,7 @@ import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
+import retrofit2.http.Streaming;
 import rx.Observable;
 
 import static com.addhen.voto.sdk.Constants.VotoEndpoints;
@@ -100,4 +103,8 @@ public interface RxJavaVotoService {
     Observable<UploadAudioFileResponse> updateAudioFileContent(@Path("id") Long id,
             @Query("file_extension") AudioFileExtension format,
             @QueryMap Map<String, String> optionalFields);
+
+    @GET(Constants.VotoEndpoints.AUDIO_FILES + "/{id}")
+    @Streaming
+    Observable<ResponseBody> downloadAudioFile(@Path("id") Long id, AudioFileFormat format);
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/RxJavaVotoApiClientTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/RxJavaVotoApiClientTest.java
@@ -19,6 +19,7 @@ package addhen.voto.sdk.rxjava.test;
 import com.addhen.voto.sdk.Constants;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
@@ -35,6 +36,7 @@ import org.junit.Test;
 import java.io.IOException;
 
 import addhen.voto.sdk.rxjava.test.service.MockRxJavaVotoService;
+import okhttp3.ResponseBody;
 import rx.Observable;
 import rx.observers.TestSubscriber;
 
@@ -222,5 +224,36 @@ public class RxJavaVotoApiClientTest extends BaseTestCase {
         } catch (IllegalArgumentException e) {
             assertEquals("fileExtension is required.", e.getMessage());
         }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenDownloadFileIdIsNull() {
+        try {
+            mRxJavaVotoApiClient.downloadAudioFile(null, AudioFileFormat.ORIGINAL);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("id cannot be null.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenDownloadFileFileFormatIsNotSet() {
+        try {
+            mRxJavaVotoApiClient.downloadAudioFile(1l, null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("format is required.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldSuccessfullyDownloadAudioFile() throws IOException {
+        Observable<ResponseBody> observable = mRxJavaVotoApiClient
+                .downloadAudioFile(1l, AudioFileFormat.ORIGINAL);
+        TestSubscriber<ResponseBody> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        ResponseBody responseBody = result.getOnNextEvents().get(0);
+        assertNotNull(responseBody);
+        assertEquals("AudioFile", responseBody.string());
     }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/MockRxJavaVotoService.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/MockRxJavaVotoService.java
@@ -18,6 +18,7 @@ package addhen.voto.sdk.rxjava.test.service;
 
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -32,6 +33,8 @@ import com.addhen.voto.sdk.test.GsonDeserializer;
 
 import java.util.Map;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import retrofit2.http.Field;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
@@ -124,5 +127,12 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
         final UploadAudioFileResponse uploadAudioFileResponse = mGsonDeserializer
                 .updateAudioFileContent();
         return Observable.just(uploadAudioFileResponse);
+    }
+
+    @Override
+    public Observable<ResponseBody> downloadAudioFile(@Path("id") Long id, AudioFileFormat format) {
+        // Return a plain text file
+        ResponseBody responseBody = ResponseBody.create(MediaType.parse("text/plain"), "AudioFile");
+        return Observable.just(responseBody);
     }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
@@ -18,6 +18,7 @@ package addhen.voto.sdk.rxjava.test.service;
 
 import com.addhen.voto.sdk.model.audio.AudioFile;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
@@ -35,6 +36,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import okhttp3.ResponseBody;
 import rx.Observable;
 import rx.observers.TestSubscriber;
 
@@ -194,5 +196,17 @@ public class RxJavaVotoServiceTest extends BaseTestCase {
         assertEquals("2013-04-09 12:57", created);
         String modified = formatDate("yyyy-MM-dd h:m", audioFile.modified);
         assertEquals("2013-04-09 12:57", modified);
+    }
+
+    @Test
+    public void shouldSuccessfullyDownloadAudioFile() throws IOException {
+        assertNotNull(mMockRxJavaVotoService);
+        Observable<ResponseBody> observable = mMockRxJavaVotoService
+                .downloadAudioFile(1l, AudioFileFormat.ORIGINAL);
+        TestSubscriber<ResponseBody> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        ResponseBody responseBody = result.getOnNextEvents().get(0);
+        assertNotNull(responseBody);
+        assertEquals("AudioFile", responseBody.string());
     }
 }

--- a/voto-sync/src/main/java/com/addhen/voto/sdk/sync/SyncVotoApiClient.java
+++ b/voto-sync/src/main/java/com/addhen/voto/sdk/sync/SyncVotoApiClient.java
@@ -19,6 +19,7 @@ import com.addhen.voto.sdk.BaseApiBuilder;
 import com.addhen.voto.sdk.BaseVotoApiClient;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -34,6 +35,7 @@ import com.addhen.voto.sdk.util.StringUtils;
 import java.io.IOException;
 import java.util.Map;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.http.QueryMap;
@@ -126,6 +128,19 @@ public class SyncVotoApiClient extends BaseVotoApiClient {
             throws IOException {
         Call<UploadAudioFileResponse> call = mSyncVotoService
                 .updateAudioFileContent(id, fileExtension, optionalFields);
+        return call.execute().body();
+    }
+
+    public ResponseBody downloadAudioFile(Long id, AudioFileFormat format) throws IOException {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null.");
+        }
+
+        if ((format == null) || (StringUtils.isEmpty(format.name()))) {
+            throw new IllegalArgumentException("format is required.");
+        }
+
+        Call<ResponseBody> call = mSyncVotoService.downloadAudioFile(id, format);
         return call.execute().body();
     }
 

--- a/voto/src/main/java/com/addhen/voto/sdk/model/audio/AudioFileFormat.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/audio/AudioFileFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016. Henry Addo Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.addhen.voto.sdk.model.audio;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * @author Henry Addo
+ */
+public enum AudioFileFormat {
+    /** The original format **/
+    @SerializedName("original")
+    ORIGINAL("original"),
+    /** The OGG format **/
+    @SerializedName("ogg")
+    OGG("ogg");
+
+    private final String mValue;
+
+    AudioFileFormat(String value) {
+        mValue = value;
+    }
+
+    @Override
+    public String toString() {
+        return mValue;
+    }
+}

--- a/voto/src/main/java/com/addhen/voto/sdk/service/VotoService.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/service/VotoService.java
@@ -19,6 +19,7 @@ package com.addhen.voto.sdk.service;
 import com.addhen.voto.sdk.Constants;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -31,6 +32,7 @@ import com.addhen.voto.sdk.model.subscribers.SubscriberDetailsResponse;
 
 import java.util.Map;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.DELETE;
 import retrofit2.http.Field;
@@ -42,6 +44,7 @@ import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
+import retrofit2.http.Streaming;
 
 /**
  * @author Henry Addo
@@ -93,4 +96,8 @@ public interface VotoService {
     Call<UploadAudioFileResponse> updateAudioFileContent(@Path("id") Long id,
             @Query("file_extension") AudioFileExtension format,
             @QueryMap Map<String, String> optionalFields);
+
+    @GET(Constants.VotoEndpoints.AUDIO_FILES + "/{id}")
+    @Streaming
+    Call<ResponseBody> downloadAudioFile(@Path("id") Long id, AudioFileFormat format);
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/MockVotoService.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/MockVotoService.java
@@ -18,6 +18,7 @@ package com.addhen.voto.sdk.test.service;
 
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileExtension;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
@@ -32,6 +33,8 @@ import com.addhen.voto.sdk.test.GsonDeserializer;
 
 import java.util.Map;
 
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Field;
 import retrofit2.http.Path;
@@ -139,5 +142,11 @@ public class MockVotoService implements VotoService {
                 .updateAudioFileContent();
         return mDelegate.returningResponse(audioFileResponse)
                 .updateAudioFileContent(id, format, optionalFields);
+    }
+
+    @Override
+    public Call<ResponseBody> downloadAudioFile(@Path("id") Long id, AudioFileFormat format) {
+        ResponseBody responseBody = ResponseBody.create(MediaType.parse("text/plain"), "AudioFile");
+        return mDelegate.returningResponse(responseBody).downloadAudioFile(id, format);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
@@ -18,6 +18,7 @@ package com.addhen.voto.sdk.test.service;
 
 import com.addhen.voto.sdk.model.audio.AudioFile;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
+import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
@@ -37,6 +38,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Random;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.mock.BehaviorDelegate;
@@ -196,5 +198,14 @@ public class VotoServiceTest extends BaseTestCase {
         assertEquals("2013-04-09 12:57", created);
         String modified = formatDate("yyyy-MM-dd h:m", audioFile.modified);
         assertEquals("2013-04-09 12:57", modified);
+    }
+
+    @Test
+    public void shouldSuccessfullyDownloadAudioFile() throws IOException {
+        assertNotNull(mMockVotoService);
+        Call<ResponseBody> call = mMockVotoService.downloadAudioFile(1l, AudioFileFormat.ORIGINAL);
+        ResponseBody responseBody = call.execute().body();
+        assertNotNull(responseBody);
+        assertEquals("AudioFile", responseBody.string());
     }
 }


### PR DESCRIPTION
Fixes #8 

This `PR` makes the following changes:
- 
Return a response body when a request to download a file is made
The user will use the response body to get an inputstream and with
the input stream can get the actual file
Add test for the implementations

Ping @eyedol