### PR TITLE
27 update message

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ rxJavaVotoApiClient.listSubscribers(10).subscribe(new Action1<ListSubscribersRes
 });
 ```
 
+### Run sample
+
+Make sure you've your VOTO API key set in the `local.properties` file located in the root directory
+of the project. The property name should be `votoApiKey`. If you don't set this, a dummy API key will be used.
+
+After setting the voto api key, issue `./gradlew run`. This should run the sample app and output the results in the console.
+
 License
 --------
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,6 +28,20 @@ mainClassName = "com.addhen.voto.sdk.sample.Main"
  */
 applicationDefaultJvmArgs = ["-Djsse.enableSNIExtension=false"]
 
+Properties properties = new Properties()
+if (project.rootProject.file('local.properties').exists()) {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+}
+
+run {
+
+    if (!properties.getProperty('votoApiKey').isEmpty()) {
+        args properties.getProperty('votoApiKey')
+    } else {
+        args 'dummi_api'
+    }
+}
+
 dependencies {
     compile project(':voto')
     compile project(':voto-sync')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -35,7 +35,8 @@ if (project.rootProject.file('local.properties').exists()) {
 
 run {
 
-    if (!properties.getProperty('votoApiKey').isEmpty()) {
+    if (properties.getProperty('votoApiKey') != null &&
+            !properties.getProperty('votoApiKey').isEmpty()) {
         args properties.getProperty('votoApiKey')
     } else {
         args 'dummi_api'

--- a/sample/src/main/java/com/addhen/voto/sdk/sample/Main.java
+++ b/sample/src/main/java/com/addhen/voto/sdk/sample/Main.java
@@ -17,6 +17,7 @@
 package com.addhen.voto.sdk.sample;
 
 import com.addhen.voto.sdk.async.AsyncVotoApiClient;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.subscribers.ListSubscribersResponse;
 import com.addhen.voto.sdk.rxjava.RxJavaVotoApiClient;
 import com.addhen.voto.sdk.sync.SyncVotoApiClient;
@@ -34,14 +35,18 @@ import rx.functions.Action1;
  */
 public class Main {
 
+    private static String api_key;
+
     public static void main(String args[]) {
+        api_key = args[0];
         syncClient();
         asyncClient();
         rxJavaClient();
+        listMessagesSyncClient();
     }
 
     private static void syncClient() {
-        SyncVotoApiClient syncVotoApiClient = new SyncVotoApiClient.Builder("api_key")
+        SyncVotoApiClient syncVotoApiClient = new SyncVotoApiClient.Builder(api_key)
                 .withLogLevel(HttpLoggingInterceptor.Level.BODY)
                 .build();
         ListSubscribersResponse listSubscribersResponse = null;
@@ -55,7 +60,7 @@ public class Main {
     }
 
     private static void asyncClient() {
-        AsyncVotoApiClient asyncVotoApiClient = new AsyncVotoApiClient.Builder("api_key")
+        AsyncVotoApiClient asyncVotoApiClient = new AsyncVotoApiClient.Builder(api_key)
                 .withLogLevel(HttpLoggingInterceptor.Level.BODY)
                 .build();
         asyncVotoApiClient.listSubscribers(10, new Callback<ListSubscribersResponse>() {
@@ -74,7 +79,7 @@ public class Main {
     }
 
     private static void rxJavaClient() {
-        RxJavaVotoApiClient rxJavaVotoApiClient = new RxJavaVotoApiClient.Builder("api_key")
+        RxJavaVotoApiClient rxJavaVotoApiClient = new RxJavaVotoApiClient.Builder(api_key)
                 .withLogLevel(HttpLoggingInterceptor.Level.BODY)
                 .build();
         rxJavaVotoApiClient.listSubscribers(10).subscribe(new Action1<ListSubscribersResponse>() {
@@ -83,5 +88,19 @@ public class Main {
                 System.out.println(listSubscribersResponse);
             }
         });
+    }
+
+    private static void listMessagesSyncClient() {
+        SyncVotoApiClient syncVotoApiClient = new SyncVotoApiClient.Builder(api_key)
+                .withLogLevel(HttpLoggingInterceptor.Level.BODY)
+                .build();
+        ListMessagesResponse listMessagesResponse = null;
+        try {
+            listMessagesResponse = syncVotoApiClient.listMessages();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println(listMessagesResponse);
     }
 }

--- a/voto-async/build.gradle
+++ b/voto-async/build.gradle
@@ -13,8 +13,8 @@ dependencies {
 }
 
 // Upload artifact to bintray repo
-/*ext {
+ext {
     artifact = 'voto-sdk-async'
     blob = 'Provides access to the VOTO API asynchronously'
 }
-apply from: '../gradle-config/bintray-upload.gradle'*/
+apply from: '../gradle-config/bintray-upload.gradle'

--- a/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
+++ b/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
@@ -210,6 +210,12 @@ public class AsyncVotoApiClient extends BaseVotoApiClient {
         call.enqueue(callback);
     }
 
+    public void updateMessage(Long id, Map<String, String> optionalFields,
+            Callback<CreateResponse> callback) {
+        Call<CreateResponse> call = mAsyncVotoService.updateMessage(id, optionalFields);
+        call.enqueue(callback);
+    }
+
     public static class Builder extends BaseApiBuilder<Builder, AsyncVotoApiClient> {
 
         public Builder(String apiKey) {

--- a/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
+++ b/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
@@ -92,7 +92,7 @@ public class AsyncVotoApiClient extends BaseVotoApiClient {
             this.limit = limit;
         }
         Call<ListSubscribersResponse> listSubscribers = mAsyncVotoService
-                .listSubscribers(limit);
+                .listSubscribers(this.limit);
         listSubscribers.enqueue(callback);
     }
 

--- a/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
+++ b/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
@@ -583,4 +583,21 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                     }
                 });
     }
+
+    @Test
+    public void shouldSuccessfullyUpdateMessage() throws IOException {
+        mAsyncVotoApiClient.updateMessage(1l, null, new Callback<CreateResponse>() {
+            @Override
+            public void onResponse(Call<CreateResponse> call, Response<CreateResponse> response) {
+                CreateResponse createResponse = response.body();
+                assertNotNull(createResponse);
+                assertEquals(200, (int) createResponse.status);
+            }
+
+            @Override
+            public void onFailure(Call<CreateResponse> call, Throwable t) {
+                // Do nothing
+            }
+        });
+    }
 }

--- a/voto-rxjava/build.gradle
+++ b/voto-rxjava/build.gradle
@@ -14,9 +14,9 @@ dependencies {
 }
 
 // Upload artifact to bintray repo
-/*ext {
+ext {
     artifact = 'voto-sdk-rxjava'
     blob = 'Uses RxJava for accessing the VOTO API'
 }
 // Upload artifact to bintray repo
-apply from: '../gradle-config/bintray-upload.gradle'*/
+apply from: '../gradle-config/bintray-upload.gradle'

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
@@ -203,6 +203,10 @@ public class RxJavaVotoApiClient extends BaseVotoApiClient {
 
     }
 
+    public Observable<CreateResponse> updateMessage(Long id, Map<String, String> optionalFields) {
+        return mRxJavaVotoService.updateMessage(id, optionalFields);
+    }
+
     public static class Builder extends BaseApiBuilder<Builder, RxJavaVotoApiClient> {
 
         public Builder(String apiKey) {

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
@@ -89,7 +89,7 @@ public class RxJavaVotoApiClient extends BaseVotoApiClient {
             this.limit = limit;
         }
         Observable<ListSubscribersResponse> listSubscribers = mRxJavaVotoService
-                .listSubscribers(limit);
+                .listSubscribers(this.limit);
         return listSubscribers;
     }
 

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/service/RxJavaVotoService.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/service/RxJavaVotoService.java
@@ -126,4 +126,10 @@ public interface RxJavaVotoService {
             @Field("has_voice") Status hasVoice,
             @FieldMap Map<String, String> optionalFields
     );
+
+    @PUT(VotoEndpoints.MESSAGES + "/{id}")
+    Observable<CreateResponse> updateMessage(
+            @Path("id") Long id,
+            @FieldMap Map<String, String> optionalFields
+    );
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/RxJavaVotoApiClientTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/RxJavaVotoApiClientTest.java
@@ -378,4 +378,16 @@ public class RxJavaVotoApiClientTest extends BaseTestCase {
         assertNotNull(createResponse);
         assertEquals(200, (int) createResponse.status);
     }
+
+    @Test
+    public void shouldSuccessfullyUpdateMessage() throws IOException {
+        Observable<CreateResponse> observable = mRxJavaVotoApiClient.updateMessage(1l, null);
+        TestSubscriber<CreateResponse> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        CreateResponse createResponse = result.getOnNextEvents().get(0);
+        assertNotNull(createResponse);
+        assertEquals(200, (int) createResponse.status);
+        assertEquals(112l, (long) createResponse.data.id);
+        assertEquals("Message Created Successfully", createResponse.message);
+    }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/MockRxJavaVotoService.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/MockRxJavaVotoService.java
@@ -38,9 +38,6 @@ import java.util.Map;
 
 import okhttp3.MediaType;
 import okhttp3.ResponseBody;
-import retrofit2.http.Field;
-import retrofit2.http.FieldMap;
-import retrofit2.http.Path;
 import retrofit2.http.Query;
 import retrofit2.http.QueryMap;
 import rx.Observable;
@@ -57,7 +54,7 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
     }
 
     @Override
-    public Observable<CreateSubscriberResponse> createSubscriber(@Field("phone") String phone,
+    public Observable<CreateSubscriberResponse> createSubscriber(String phone,
             @QueryMap Map<String, String> optionalFields) {
         final CreateSubscriberResponse createSubscriberResponse = mGsonDeserializer
                 .deserializeCreateSubscriberResponse();
@@ -66,37 +63,36 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
 
     @Override
     public Observable<CreateBulkSubscribersResponse> createBulkSubscribers(
-            @Field("phone_numbers") String phone,
-            @Field("if_phone_number_exists") IfPhoneNumberExists ifPhoneNumberExists,
-            @QueryMap Map<String, String> optionalFields) {
+            String phone, IfPhoneNumberExists ifPhoneNumberExists,
+            Map<String, String> optionalFields) {
         final CreateBulkSubscribersResponse createBulkSubscribersResponse = mGsonDeserializer
                 .deserializeCreateBulkSubscriberResponse();
         return Observable.just(createBulkSubscribersResponse);
     }
 
     @Override
-    public Observable<ListSubscribersResponse> listSubscribers(@Query("limit") int limit) {
+    public Observable<ListSubscribersResponse> listSubscribers(int limit) {
         final ListSubscribersResponse listSubscribersResponse = mGsonDeserializer.listSubscribers();
         return Observable.just(listSubscribersResponse);
     }
 
     @Override
-    public Observable<CreateSubscriberResponse> modifySubscriberDetails(@Path("id") Long id,
-            @QueryMap Map<String, String> optionalFields) {
+    public Observable<CreateSubscriberResponse> modifySubscriberDetails(Long id,
+            Map<String, String> optionalFields) {
         final CreateSubscriberResponse createSubscriberResponse = mGsonDeserializer
                 .modifySubscriberDetails();
         return Observable.just(createSubscriberResponse);
     }
 
     @Override
-    public Observable<DeleteSubscriberResponse> deleteSubscriber(@Path("id") Long id) {
+    public Observable<DeleteSubscriberResponse> deleteSubscriber(Long id) {
         final DeleteSubscriberResponse deleteSubscriberResponse = mGsonDeserializer
                 .deleteSubscriber();
         return Observable.just(deleteSubscriberResponse);
     }
 
     @Override
-    public Observable<SubscriberDetailsResponse> listSubscriberDetails(@Path("id") Long id) {
+    public Observable<SubscriberDetailsResponse> listSubscriberDetails(Long id) {
         final SubscriberDetailsResponse response = mGsonDeserializer.listSubscriberDetails();
         return Observable.just(response);
     }
@@ -108,13 +104,13 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
     }
 
     @Override
-    public Observable<DeleteAudioFileResponse> deleteAudioFile(@Path("id") Long id) {
+    public Observable<DeleteAudioFileResponse> deleteAudioFile(Long id) {
         final DeleteAudioFileResponse deleteAudioFileResponse = mGsonDeserializer.deleteAudioFile();
         return Observable.just(deleteAudioFileResponse);
     }
 
     @Override
-    public Observable<AudioFileDetailsResponse> listAudioFileDetails(@Path("id") Long id) {
+    public Observable<AudioFileDetailsResponse> listAudioFileDetails(Long id) {
         final AudioFileDetailsResponse audioFileResponse = mGsonDeserializer.listAudioFileDetails();
         return Observable.just(audioFileResponse);
     }
@@ -130,9 +126,8 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
     }
 
     @Override
-    public Observable<UploadAudioFileResponse> updateAudioFileContent(@Path("id") Long id,
-            @Query("file_extension") AudioFileExtension format,
-            @QueryMap Map<String, String> optionalFields) {
+    public Observable<UploadAudioFileResponse> updateAudioFileContent(Long id,
+            AudioFileExtension format, Map<String, String> optionalFields) {
 
         final UploadAudioFileResponse uploadAudioFileResponse = mGsonDeserializer
                 .updateAudioFileContent();
@@ -140,7 +135,7 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
     }
 
     @Override
-    public Observable<ResponseBody> downloadAudioFile(@Path("id") Long id, AudioFileFormat format) {
+    public Observable<ResponseBody> downloadAudioFile(Long id, AudioFileFormat format) {
         // Return a plain text file
         ResponseBody responseBody = ResponseBody.create(MediaType.parse("text/plain"), "AudioFile");
         return Observable.just(responseBody);
@@ -153,10 +148,15 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
     }
 
     @Override
-    public Observable<CreateResponse> createMessage(@Field("title") String title,
-            @Field("has_sms") Status hasSms, @Field("has_voice") Status hasVoice,
-            @FieldMap Map<String, String> optionalFields) {
+    public Observable<CreateResponse> createMessage(String title,
+            Status hasSms, Status hasVoice, Map<String, String> optionalFields) {
         final CreateResponse createResponse = mGsonDeserializer.createMessage();
+        return Observable.just(createResponse);
+    }
+
+    @Override
+    public Observable<CreateResponse> updateMessage(Long id, Map<String, String> optionalFields) {
+        final CreateResponse createResponse = mGsonDeserializer.updateMessage();
         return Observable.just(createResponse);
     }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
@@ -16,11 +16,14 @@
 
 package addhen.voto.sdk.rxjava.test.service;
 
+import com.addhen.voto.sdk.model.CreateResponse;
 import com.addhen.voto.sdk.model.audio.AudioFile;
 import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.Message;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -256,5 +259,55 @@ public class RxJavaVotoServiceTest extends BaseTestCase {
         ResponseBody responseBody = result.getOnNextEvents().get(0);
         assertNotNull(responseBody);
         assertEquals("AudioFile", responseBody.string());
+    }
+
+    @Test
+    public void shouldSuccessfullyCreateMessage() throws IOException {
+        assertNotNull(mMockRxJavaVotoService);
+        Observable<CreateResponse> observable = mMockRxJavaVotoService.createMessage("title",
+                com.addhen.voto.sdk.model.Status.NO, com.addhen.voto.sdk.model.Status.YES, null);
+        TestSubscriber<CreateResponse> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        CreateResponse createResponse = result.getOnNextEvents().get(0);
+        assertNotNull(createResponse);
+        assertEquals(200, (int) createResponse.status);
+        assertEquals(112l, (long) createResponse.data.id);
+        assertEquals("Message Created Successfully", createResponse.message);
+    }
+
+    @Test
+    public void shouldSuccessfullyListMessages() throws IOException {
+        assertNotNull(mMockRxJavaVotoService);
+        Observable<ListMessagesResponse> observable = mMockRxJavaVotoService.listMessages();
+        TestSubscriber<ListMessagesResponse> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        ListMessagesResponse listMessagesResponse = result.getOnNextEvents().get(0);
+        assertNotNull(listMessagesResponse);
+        assertEquals(200, (int) listMessagesResponse.status);
+        Message message = listMessagesResponse.data.messages.get(0);
+        assertNotNull(message);
+        assertEquals(201712, (long) message.id);
+        assertEquals("Test release 15 Sep 2014 ", message.title);
+        assertEquals(com.addhen.voto.sdk.model.Status.YES, message.hasSms);
+        assertEquals(com.addhen.voto.sdk.model.Status.YES, message.hasVoice);
+        System.out.println("Date: " + message);
+        String created = formatDate("yyyy-MM-dd H:mm:ss", message.created);
+        System.out.println("Created: " + created);
+        assertEquals("2014-09-15 16:20:48", created);
+        String modified = formatDate("yyyy-MM-dd H:mm:ss", message.modified);
+        assertEquals("2014-09-15 16:20:48", modified);
+    }
+
+    @Test
+    public void shouldSuccessfullyUpdateMessages() throws IOException {
+        assertNotNull(mMockRxJavaVotoService);
+        Observable<CreateResponse> observable = mMockRxJavaVotoService.updateMessage(112l, null);
+        TestSubscriber<CreateResponse> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        CreateResponse createResponse = result.getOnNextEvents().get(0);
+        assertNotNull(createResponse);
+        assertEquals(200, (int) createResponse.status);
+        assertEquals(112l, (long) createResponse.data.id);
+        assertEquals("Message Created Successfully", createResponse.message);
     }
 }

--- a/voto-sync/build.gradle
+++ b/voto-sync/build.gradle
@@ -14,9 +14,9 @@ dependencies {
     testCompile sdkTestDependencies.retrofitMock
 }
 
-/*ext {
+ext {
     artifact = 'voto-sdk-sync'
     blob = 'Provides access to the VOTO API synchronously'
 }
 // Upload artifact to bintray repo
-apply from: '../gradle-config/bintray-upload.gradle'*/
+apply from: '../gradle-config/bintray-upload.gradle'

--- a/voto-sync/src/main/java/com/addhen/voto/sdk/sync/SyncVotoApiClient.java
+++ b/voto-sync/src/main/java/com/addhen/voto/sdk/sync/SyncVotoApiClient.java
@@ -205,6 +205,12 @@ public class SyncVotoApiClient extends BaseVotoApiClient {
         return call.execute().body();
     }
 
+    public CreateResponse updateMessage(Long id, Map<String, String> optionalFields)
+            throws IOException {
+        Call<CreateResponse> call = mSyncVotoService.updateMessage(id, optionalFields);
+        return call.execute().body();
+    }
+
     public static class Builder extends BaseApiBuilder<Builder, SyncVotoApiClient> {
 
         public Builder(String apiKey) {

--- a/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
+++ b/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
@@ -378,4 +378,11 @@ public class SyncVotoApiClientTest extends BaseTestCase {
         assertNotNull(createResponse);
         assertEquals(200, (int) createResponse.status);
     }
+
+    @Test
+    public void shouldSuccessfullyUpdateMessage() throws IOException {
+        CreateResponse createResponse = mSyncVotoApiClient.updateMessage(1l, null);
+        assertNotNull(createResponse);
+        assertEquals(200, (int) createResponse.status);
+    }
 }

--- a/voto/src/main/java/com/addhen/voto/sdk/model/messages/Message.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/messages/Message.java
@@ -42,7 +42,7 @@ public class Message extends Model {
     public Date created;
 
     /** The date the audio file was modified **/
-    @SerializedName("modified_at")
+    @SerializedName("updated_at")
     public Date modified;
 
     public Message(Long id, String title, Status hasVoice, Status hasSms, Date created,

--- a/voto/src/main/java/com/addhen/voto/sdk/service/VotoService.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/service/VotoService.java
@@ -119,4 +119,10 @@ public interface VotoService {
             @Field("has_voice") Status hasVoice,
             @FieldMap Map<String, String> optionalFields
     );
+
+    @PUT(Constants.VotoEndpoints.MESSAGES + "/{id}")
+    Call<CreateResponse> updateMessage(
+            @Path("id") Long id,
+            @FieldMap Map<String, String> optionalFields
+    );
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/GsonDeserializer.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/GsonDeserializer.java
@@ -165,6 +165,10 @@ public final class GsonDeserializer {
         return createResponse("json/message/create_message_response.json");
     }
 
+    public CreateResponse updateMessage() {
+        return createMessage();
+    }
+
     public CreateResponse createResponse(String responseJson) {
         String createResponse = null;
         try {

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/MockVotoService.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/MockVotoService.java
@@ -174,4 +174,11 @@ public class MockVotoService implements VotoService {
         return mDelegate.returningResponse(createResponse)
                 .createMessage(title, hasSms, hasVoice, optionalFields);
     }
+
+    @Override
+    public Call<CreateResponse> updateMessage(@Path("id") Long id,
+            @FieldMap Map<String, String> optionalFields) {
+        final CreateResponse createResponse = mGsonDeserializer.updateMessage();
+        return mDelegate.returningResponse(createResponse).updateMessage(id, optionalFields);
+    }
 }


### PR DESCRIPTION
Fixes #27 

This `PR` makes the following changes:
- Add missing implementation for create message in async client
- Add test for message update
- Make Sample project's API key configurable via the local.properties file
- Include sample code for listing messages
- Update README to include how to run sample project


Ping @eyedol