### PR TITLE
30 count message delivery logs

### DIFF
--- a/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
+++ b/voto-async/src/main/java/com/addhen/voto/sdk/async/AsyncVotoApiClient.java
@@ -27,6 +27,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -219,6 +220,14 @@ public class AsyncVotoApiClient extends BaseVotoApiClient {
 
     public void deleteMessage(Long id, Callback<DeleteMessageResponse> callback) {
         Call<DeleteMessageResponse> call = mAsyncVotoService.deleteMessage(id);
+        call.enqueue(callback);
+    }
+
+    public void getMessageDeliveryLog(Long id,
+            @QueryMap Map<String, String> optionalFields,
+            Callback<MessageDeliveryLogResponse> callback) {
+        Call<MessageDeliveryLogResponse> call = mAsyncVotoService
+                .getMessageDeliveryLog(id, optionalFields);
         call.enqueue(callback);
     }
 

--- a/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
+++ b/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
@@ -278,14 +278,15 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
     }
 
     @Test
-    public void shouldSuccessfullyListAudioFileDetails() throws IOException {
+    public void shouldSuccessfullyListAudioFileDetails() throws IOException, InterruptedException {
+        final AtomicReference<AudioFileDetailsResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient
                 .listAudioFileDetails(1l, new Callback<AudioFileDetailsResponse>() {
                     @Override
                     public void onResponse(Call<AudioFileDetailsResponse> call,
                             Response<AudioFileDetailsResponse> resp) {
-                        AudioFileDetailsResponse response = resp.body();
-                        assertNotNull(response);
+                        actual.set(resp.body());
+                        mCountDownLatch.countDown();
                     }
 
                     @Override
@@ -293,18 +294,22 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                         // Do nothing
                     }
                 });
+        setCountDownLatchTime();
+        AudioFileDetailsResponse response = actual.get();
+        assertNotNull(response);
     }
 
     @Test
-    public void shouldSuccessfullyUploadAudioFileContent() throws IOException {
+    public void shouldSuccessfullyUploadAudioFileContent()
+            throws IOException, InterruptedException {
+        final AtomicReference<UploadAudioFileResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient
                 .uploadAudioFileContent("description",
                         AudioFileExtension.MP3, null, new Callback<UploadAudioFileResponse>() {
                             @Override
                             public void onResponse(Call<UploadAudioFileResponse> call,
                                     Response<UploadAudioFileResponse> resp) {
-                                UploadAudioFileResponse response = resp.body();
-                                assertNotNull(response);
+                                actual.set(resp.body());
                             }
 
                             @Override
@@ -312,18 +317,23 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                                 //Do nothing
                             }
                         });
+        setCountDownLatchTime();
+        UploadAudioFileResponse response = actual.get();
+        assertNotNull(response);
     }
 
     @Test
-    public void shouldSuccessfullyUpdateAudioFileContent() throws IOException {
+    public void shouldSuccessfullyUpdateAudioFileContent()
+            throws IOException, InterruptedException {
+        final AtomicReference<UploadAudioFileResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient
                 .updateAudioFileContent(1l, AudioFileExtension.MP3, null,
                         new Callback<UploadAudioFileResponse>() {
                             @Override
                             public void onResponse(Call<UploadAudioFileResponse> call,
                                     Response<UploadAudioFileResponse> resp) {
-                                UploadAudioFileResponse response = resp.body();
-                                assertNotNull(response);
+                                actual.set(resp.body());
+                                mCountDownLatch.countDown();
                             }
 
                             @Override
@@ -331,6 +341,9 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                                 //Do nothing
                             }
                         });
+        setCountDownLatchTime();
+        UploadAudioFileResponse response = actual.get();
+        assertNotNull(response);
     }
 
     @Test
@@ -350,7 +363,7 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
     }
 
     @Test
-    public void shouldMakeSureLimitIsSet() throws IOException {
+    public void shouldMakeSureLimitIsSet() throws IOException, InterruptedException {
         mAsyncVotoApiClient.listSubscribers(2, new Callback<ListSubscribersResponse>() {
             @Override
             public void onResponse(Call<ListSubscribersResponse> call,
@@ -485,166 +498,199 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
     }
 
     @Test
-    public void shouldSuccessfullyDownloadAudioFile() throws IOException {
+    public void shouldSuccessfullyDownloadAudioFile() throws IOException, InterruptedException {
+        final AtomicReference<ResponseBody> actual = new AtomicReference<>();
         mAsyncVotoApiClient
                 .downloadAudioFile(1l, AudioFileFormat.ORIGINAL, new Callback<ResponseBody>() {
                     @Override
                     public void onResponse(Call<ResponseBody> call,
                             Response<ResponseBody> resp) {
-                        ResponseBody responseBody = resp.body();
-                        assertNotNull(responseBody);
-                        try {
-                            assertEquals("AudioFile", responseBody.string());
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
+                        actual.set(resp.body());
+                        mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<ResponseBody> call, Throwable t) {
-
+                        throw new AssertionError();
                     }
                 });
+        setCountDownLatchTime();
+        ResponseBody responseBody = actual.get();
+        assertNotNull(responseBody);
+        try {
+            assertEquals("AudioFile", responseBody.string());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
-    public void shouldSuccessfullyDeleteAudioFile() throws IOException {
+    public void shouldSuccessfullyDeleteAudioFile() throws IOException, InterruptedException {
+        final AtomicReference<DeleteAudioFileResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.deleteAudioFile(1l,
                 new Callback<DeleteAudioFileResponse>() {
                     @Override
                     public void onResponse(Call<DeleteAudioFileResponse> call,
                             Response<DeleteAudioFileResponse> resp) {
-                        DeleteAudioFileResponse audioFileResponse = resp.body();
-                        assertNotNull(audioFileResponse);
-                        assertEquals(200, (int) audioFileResponse.status);
-                        assertEquals("Successfully deleted audio file", audioFileResponse.message);
+                        actual.set(resp.body());
+                        mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<DeleteAudioFileResponse> call, Throwable t) {
-                        // Do nothing
+                        throw new AssertionError();
                     }
                 });
+        setCountDownLatchTime();
+        DeleteAudioFileResponse audioFileResponse = actual.get();
+        assertNotNull(audioFileResponse);
+        assertEquals(200, (int) audioFileResponse.status);
+        assertEquals("Successfully deleted audio file", audioFileResponse.message);
     }
 
     @Test
-    public void shouldSuccessfullyListAudioFile() throws IOException {
+    public void shouldSuccessfullyListAudioFile() throws IOException, InterruptedException {
+        final AtomicReference<ListAudioFilesResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.listAudioFiles(
                 new Callback<ListAudioFilesResponse>() {
                     @Override
                     public void onResponse(Call<ListAudioFilesResponse> call,
                             Response<ListAudioFilesResponse> resp) {
-                        ListAudioFilesResponse audioFilesResponse = resp.body();
-                        assertNotNull(audioFilesResponse);
-                        assertEquals(200, (int) audioFilesResponse.status);
+                        actual.set(resp.body());
+                        mCountDownLatch.countDown();
+
                     }
 
                     @Override
                     public void onFailure(Call<ListAudioFilesResponse> call, Throwable t) {
-                        // Do nothing
+                        throw new AssertionError();
                     }
                 });
+        setCountDownLatchTime();
+        ListAudioFilesResponse audioFilesResponse = actual.get();
+        assertNotNull(audioFilesResponse);
+        assertEquals(200, (int) audioFilesResponse.status);
     }
 
     @Test
-    public void shouldSuccessfullyListMessages() throws IOException {
+    public void shouldSuccessfullyListMessages() throws IOException, InterruptedException {
+        final AtomicReference<ListMessagesResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.listMessages(new Callback<ListMessagesResponse>() {
             @Override
             public void onResponse(Call<ListMessagesResponse> call,
                     Response<ListMessagesResponse> response) {
-                ListMessagesResponse listMessagesResponse = response.body();
-                assertNotNull(listMessagesResponse);
-                assertEquals(200, (int) listMessagesResponse.status);
+                actual.set(response.body());
+                mCountDownLatch.countDown();
             }
 
             @Override
             public void onFailure(Call<ListMessagesResponse> call, Throwable t) {
-                // Do nothing
+                throw new AssertionError();
             }
         });
+        setCountDownLatchTime();
+        ListMessagesResponse listMessagesResponse = actual.get();
+        assertNotNull(listMessagesResponse);
+        assertEquals(200, (int) listMessagesResponse.status);
     }
 
     @Test
-    public void shouldSuccessfullyCreateMessages() throws IOException {
+    public void shouldSuccessfullyCreateMessages() throws IOException, InterruptedException {
+        final AtomicReference<CreateResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.createMessage("title", com.addhen.voto.sdk.model.Status.NO,
                 com.addhen.voto.sdk.model.Status.YES, null, new Callback<CreateResponse>() {
                     @Override
                     public void onResponse(Call<CreateResponse> call,
                             Response<CreateResponse> response) {
-                        CreateResponse createResponse = response.body();
-                        assertNotNull(createResponse);
-                        assertEquals(200, (int) createResponse.status);
+                        actual.set(response.body());
+                        mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<CreateResponse> call, Throwable t) {
-                        // Do nothing
+                        throw new AssertionError();
                     }
                 });
+        setCountDownLatchTime();
+        CreateResponse createResponse = actual.get();
+        assertNotNull(createResponse);
+        assertEquals(200, (int) createResponse.status);
     }
 
     @Test
-    public void shouldSuccessfullyUpdateMessage() throws IOException {
+    public void shouldSuccessfullyUpdateMessage() throws IOException, InterruptedException {
+        final AtomicReference<CreateResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.updateMessage(1l, null, new Callback<CreateResponse>() {
             @Override
             public void onResponse(Call<CreateResponse> call, Response<CreateResponse> response) {
-                CreateResponse createResponse = response.body();
-                assertNotNull(createResponse);
-                assertEquals(200, (int) createResponse.status);
+                actual.set(response.body());
+                mCountDownLatch.countDown();
             }
 
             @Override
             public void onFailure(Call<CreateResponse> call, Throwable t) {
-                // Do nothing
+                throw new AssertionError();
             }
         });
+        setCountDownLatchTime();
+        CreateResponse createResponse = actual.get();
+        assertNotNull(createResponse);
+        assertEquals(200, (int) createResponse.status);
     }
 
     @Test
-    public void shouldSuccessfullyDeleteMessage() throws IOException {
+    public void shouldSuccessfullyDeleteMessage() throws IOException, InterruptedException {
+        final AtomicReference<DeleteMessageResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.deleteMessage(1l, new Callback<DeleteMessageResponse>() {
             @Override
             public void onResponse(Call<DeleteMessageResponse> call,
                     Response<DeleteMessageResponse> response) {
-                DeleteMessageResponse deleteMessageResponse = response.body();
-                assertNotNull(deleteMessageResponse);
-                assertEquals(200, (int) deleteMessageResponse.status);
-                assertEquals("Successfully deleted message", deleteMessageResponse.message);
+                actual.set(response.body());
+                mCountDownLatch.countDown();
             }
 
             @Override
             public void onFailure(Call<DeleteMessageResponse> call, Throwable t) {
-                // Do nothing
+                throw new AssertionError();
             }
         });
-
+        setCountDownLatchTime();
+        DeleteMessageResponse deleteMessageResponse = actual.get();
+        assertNotNull(deleteMessageResponse);
+        assertEquals(200, (int) deleteMessageResponse.status);
+        assertEquals("Successfully deleted message", deleteMessageResponse.message);
     }
 
     @Test
-    public void shouldSuccessfullyGetMessageDeliveryLogCount() throws IOException {
+    public void shouldSuccessfullyGetMessageDeliveryLogCount()
+            throws IOException, InterruptedException {
+        final AtomicReference<MessageDeliveryLogResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.getMessageDeliveryLog(1l, null,
                 new Callback<MessageDeliveryLogResponse>() {
                     @Override
                     public void onResponse(Call<MessageDeliveryLogResponse> call,
                             Response<MessageDeliveryLogResponse> response) {
-                        MessageDeliveryLogResponse messageDeliveryLogResponse = response.body();
-                        assertNotNull(messageDeliveryLogResponse);
-                        assertNotNull(messageDeliveryLogResponse);
-                        assertEquals(200, (int) messageDeliveryLogResponse.status);
-                        assertEquals(1000, (int) messageDeliveryLogResponse.code);
-                        assertNotNull(messageDeliveryLogResponse.data);
-                        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
-                        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
-                        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
-                        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
-                        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
+                        actual.set(response.body());
+                        mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<MessageDeliveryLogResponse> call, Throwable t) {
-                        // Do nothing
+                        throw new AssertionError();
                     }
                 });
+        setCountDownLatchTime();
+        MessageDeliveryLogResponse messageDeliveryLogResponse = actual.get();
+        assertNotNull(messageDeliveryLogResponse);
+        assertNotNull(messageDeliveryLogResponse);
+        assertEquals(200, (int) messageDeliveryLogResponse.status);
+        assertEquals(1000, (int) messageDeliveryLogResponse.code);
+        assertNotNull(messageDeliveryLogResponse.data);
+        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
+        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
+        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
+        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
     }
 
     private void setCountDownLatchTime() throws InterruptedException {

--- a/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
+++ b/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
@@ -681,16 +681,7 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                 });
         setCountDownLatchTime();
         MessageDeliveryLogResponse messageDeliveryLogResponse = actual.get();
-        assertNotNull(messageDeliveryLogResponse);
-        assertNotNull(messageDeliveryLogResponse);
-        assertEquals(200, (int) messageDeliveryLogResponse.status);
-        assertEquals(1000, (int) messageDeliveryLogResponse.code);
-        assertNotNull(messageDeliveryLogResponse.data);
-        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
-        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
-        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
-        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
-        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
+        assertMessageDeliveryLogCountResponse(messageDeliveryLogResponse);
     }
 
     private void setCountDownLatchTime() throws InterruptedException {

--- a/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
+++ b/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
@@ -25,6 +25,7 @@ import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
+import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
@@ -600,6 +601,26 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                 // Do nothing
             }
         });
+    }
+
+    @Test
+    public void shouldSuccessfullyDeleteMessage() throws IOException {
+        mAsyncVotoApiClient.deleteMessage(1l, new Callback<DeleteMessageResponse>() {
+            @Override
+            public void onResponse(Call<DeleteMessageResponse> call,
+                    Response<DeleteMessageResponse> response) {
+                DeleteMessageResponse deleteMessageResponse = response.body();
+                assertNotNull(deleteMessageResponse);
+                assertEquals(200, (int) deleteMessageResponse.status);
+                assertEquals("Successfully deleted message", deleteMessageResponse.message);
+            }
+
+            @Override
+            public void onFailure(Call<DeleteMessageResponse> call, Throwable t) {
+                // Do nothing
+            }
+        });
+
     }
 
     @Test

--- a/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
+++ b/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
@@ -67,7 +68,7 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
 
     private AsyncVotoApiClient mAsyncVotoApiClient;
 
-    private CountDownLatch mCountDownLatch = new CountDownLatch(1);
+    private final CountDownLatch mCountDownLatch = new CountDownLatch(1);
 
     @Before
     public void setUp() throws Exception {
@@ -116,168 +117,164 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                         assertNotNull(createSubscriberResponse);
                         assertNotNull(createSubscriberResponse.data);
                         assertEquals(11, (long) createSubscriberResponse.data.id);
-                        mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<CreateSubscriberResponse> call, Throwable t) {
-                        mCountDownLatch.countDown();
 
                     }
                 });
-
-        mCountDownLatch.await(30, TimeUnit.SECONDS);
     }
 
     @Test
     public void shouldSuccessfullyCreateBulkSubscribers() throws IOException, InterruptedException {
-
+        final AtomicReference<CreateBulkSubscribersResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.createBulkSubscribers("02345", null, null,
                 new Callback<CreateBulkSubscribersResponse>() {
                     @Override
                     public void onResponse(Call<CreateBulkSubscribersResponse> call,
                             Response<CreateBulkSubscribersResponse> resp) {
-                        CreateBulkSubscribersResponse response = resp.body();
-                        assertNotNull(response);
-                        assertEquals(200, (int) response.status);
-                        assertEquals("Subscriber(s) Created Successfully..",
-                                response.message);
-                        assertEquals(5, response.data.size());
-                        assertEquals(181, (long) response.data.get(0));
-
-                        //Release latch
+                        actual.set(resp.body());
                         mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<CreateBulkSubscribersResponse> call,
                             Throwable t) {
-
+                        throw new AssertionError();
                     }
                 });
-
-        mCountDownLatch.await(40, TimeUnit.SECONDS);
+        setCountDownLatchTime();
+        CreateBulkSubscribersResponse response = actual.get();
+        assertNotNull(response);
+        assertEquals(200, (int) response.status);
+        assertEquals("Subscriber(s) Created Successfully", response.message);
+        assertEquals(5, response.data.size());
+        assertEquals(181, (long) response.data.get(0));
     }
 
     @Test
     public void shouldSuccessfullyDeleteSubscriber() throws IOException, InterruptedException {
-
+        final AtomicReference<DeleteSubscriberResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.deleteSubscriber(1l,
                 new Callback<DeleteSubscriberResponse>() {
                     @Override
                     public void onResponse(Call<DeleteSubscriberResponse> call,
                             Response<DeleteSubscriberResponse> resp) {
-                        DeleteSubscriberResponse response = resp.body();
-                        assertNotNull(response);
-                        assertEquals(200, (int) response.status);
-                        assertEquals("Successfully deleted subscriber", response.message);
+                        actual.set(resp.body());
                         mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<DeleteSubscriberResponse> call, Throwable t) {
-                        mCountDownLatch.countDown();
                     }
                 });
-        mCountDownLatch.await(40, TimeUnit.SECONDS);
+        setCountDownLatchTime();
+        DeleteSubscriberResponse response = actual.get();
+        assertNotNull(response);
+        assertEquals(200, (int) response.status);
+        assertEquals("Successfully deleted subscriber", response.message);
     }
 
     @Test
     public void shouldSuccessfullyListSubscribers() throws IOException, InterruptedException {
-
+        final AtomicReference<ListSubscribersResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient.listSubscribers(10,
                 new Callback<ListSubscribersResponse>() {
                     @Override
                     public void onResponse(Call<ListSubscribersResponse> call,
                             Response<ListSubscribersResponse> resp) {
-                        ListSubscribersResponse response = resp.body();
-                        assertNotNull(response);
-                        assertEquals(200, (int) response.status);
-                        assertEquals(1001, (int) response.code);
-                        assertEquals("Subscribers fetched successfully", response.message);
-                        assertEquals("", response.moreInfo);
-                        assertNotNull(response.message);
-                        assertEquals("https://go.votomobile.org/api/v1/subscribers?limit=2",
-                                response.url);
-                        assertEquals(
-                                "https://go.votomobile.org/api/v1/subscribers?limit=2&page_after=376089",
-                                response.pagination.nextURL);
-                        assertNull(response.pagination.previousURL);
-                        assertNotNull(response.data.subscribers);
-                        assertEquals(2, response.data.subscribers.size());
-                        assertNotNull(response.data.subscribers.get(0));
-                        assertEquals(373648l, (long) response.data.subscribers.get(0).id);
-                        assertEquals("0", response.data.subscribers.get(0).receiveSms);
-                        assertEquals("1", response.data.subscribers.get(0).receiveVoice);
-                        assertEquals("0", response.data.subscribers.get(0).receiveData);
-                        assertEquals("0", response.data.subscribers.get(0).receiveUssd);
-                        assertEquals("233264164182", response.data.subscribers.get(0).phone);
-                        assertEquals(Status.ACTIVE, response.data.subscribers.get(0).status);
-                        String date = BaseTestCase
-                                .formatShowingDate(response.data.subscribers.get(0).startDate);
-                        assertEquals("2014-09-10", date);
-                        assertEquals(200247l, (long) response.data.subscribers.get(0).languageId);
-                        assertEquals("0", response.data.subscribers.get(0).isTestSubscriber);
-                        assertEquals(
-                                "201031, 201409, 204128, 204129, 204130, 204131, 204132, 204133, 204134, 204135, 204136, 204137",
-                                response.data.subscribers.get(0).groupIds);
-                        assertNotNull(response.data.subscribers.get(0).properties);
-                        assertEquals("Kodjo Antwi",
-                                response.data.subscribers.get(0).properties.name);
-                        assertEquals("Ejisu", response.data.subscribers.get(0).properties.location);
-                        assertEquals("Out flying kites",
-                                response.data.subscribers.get(0).properties.comments);
+                        actual.set(resp.body());
                         mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<ListSubscribersResponse> call, Throwable t) {
-                        mCountDownLatch.countDown();
+                        throw new AssertionError();
                     }
                 });
-        mCountDownLatch.await(40, TimeUnit.SECONDS);
+        setCountDownLatchTime();
+        ListSubscribersResponse response = actual.get();
+        assertNotNull(response);
+        assertEquals(200, (int) response.status);
+        assertEquals(1001, (int) response.code);
+        assertEquals("Subscribers fetched successfully", response.message);
+        assertEquals("", response.moreInfo);
+        assertNotNull(response.message);
+        assertEquals("https://go.votomobile.org/api/v1/subscribers?limit=2",
+                response.url);
+        assertEquals(
+                "https://go.votomobile.org/api/v1/subscribers?limit=2&page_after=376089",
+                response.pagination.nextURL);
+        assertNull(response.pagination.previousURL);
+        assertNotNull(response.data.subscribers);
+        assertEquals(2, response.data.subscribers.size());
+        assertNotNull(response.data.subscribers.get(0));
+        assertEquals(373648l, (long) response.data.subscribers.get(0).id);
+        assertEquals("0", response.data.subscribers.get(0).receiveSms);
+        assertEquals("1", response.data.subscribers.get(0).receiveVoice);
+        assertEquals("0", response.data.subscribers.get(0).receiveData);
+        assertEquals("0", response.data.subscribers.get(0).receiveUssd);
+        assertEquals("233264164182", response.data.subscribers.get(0).phone);
+        assertEquals(Status.ACTIVE, response.data.subscribers.get(0).status);
+        String date = BaseTestCase
+                .formatShowingDate(response.data.subscribers.get(0).startDate);
+        assertEquals("2014-09-10", date);
+        assertEquals(200247l, (long) response.data.subscribers.get(0).languageId);
+        assertEquals("0", response.data.subscribers.get(0).isTestSubscriber);
+        assertEquals(
+                "201031, 201409, 204128, 204129, 204130, 204131, 204132, 204133, 204134, 204135, 204136, 204137",
+                response.data.subscribers.get(0).groupIds);
+        assertNotNull(response.data.subscribers.get(0).properties);
+        assertEquals("Kodjo Antwi",
+                response.data.subscribers.get(0).properties.name);
+        assertEquals("Ejisu", response.data.subscribers.get(0).properties.location);
+        assertEquals("Out flying kites",
+                response.data.subscribers.get(0).properties.comments);
     }
 
     @Test
     public void shouldSuccessfullyModifySubscriber() throws IOException, InterruptedException {
+        final AtomicReference<CreateSubscriberResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient
                 .modifySubscriberDetails(1l, null, new Callback<CreateSubscriberResponse>() {
                     @Override
                     public void onResponse(Call<CreateSubscriberResponse> call,
                             Response<CreateSubscriberResponse> resp) {
-                        CreateSubscriberResponse createSubscriberResponse = resp.body();
-                        assertNotNull(createSubscriberResponse);
+                        actual.set(resp.body());
                         mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<CreateSubscriberResponse> call, Throwable t) {
-                        // Do nothing
-                        mCountDownLatch.countDown();
+                        throw new AssertionError();
                     }
                 });
-        mCountDownLatch.await(40, TimeUnit.SECONDS);
+        setCountDownLatchTime();
+        CreateSubscriberResponse createSubscriberResponse = actual.get();
+        assertNotNull(createSubscriberResponse);
     }
 
     @Test
     public void shouldSuccessfullyListSubscriberDetails() throws IOException, InterruptedException {
+        final AtomicReference<SubscriberDetailsResponse> actual = new AtomicReference<>();
         mAsyncVotoApiClient
                 .listSubscriberDetails(1l, new Callback<SubscriberDetailsResponse>() {
                     @Override
                     public void onResponse(Call<SubscriberDetailsResponse> call,
                             Response<SubscriberDetailsResponse> resp) {
-                        SubscriberDetailsResponse createSubscriberResponse = resp.body();
-                        assertNotNull(createSubscriberResponse);
+                        actual.set(resp.body());
                         mCountDownLatch.countDown();
                     }
 
                     @Override
                     public void onFailure(Call<SubscriberDetailsResponse> call, Throwable t) {
-                        // Do nothing
-                        mCountDownLatch.countDown();
+                        throw new AssertionError();
                     }
                 });
-        mCountDownLatch.await(40, TimeUnit.SECONDS);
+        setCountDownLatchTime();
+        SubscriberDetailsResponse createSubscriberResponse = actual.get();
+        assertNotNull(createSubscriberResponse);
     }
 
     @Test
@@ -648,5 +645,9 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                         // Do nothing
                     }
                 });
+    }
+
+    private void setCountDownLatchTime() throws InterruptedException {
+        mCountDownLatch.await(10, TimeUnit.SECONDS);
     }
 }

--- a/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
+++ b/voto-async/src/test/java/com/addhen/voto/sdk/async/test/AsyncVotoApiClientTest.java
@@ -26,6 +26,7 @@ import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -599,5 +600,32 @@ public class AsyncVotoApiClientTest extends BaseTestCase {
                 // Do nothing
             }
         });
+    }
+
+    @Test
+    public void shouldSuccessfullyGetMessageDeliveryLogCount() throws IOException {
+        mAsyncVotoApiClient.getMessageDeliveryLog(1l, null,
+                new Callback<MessageDeliveryLogResponse>() {
+                    @Override
+                    public void onResponse(Call<MessageDeliveryLogResponse> call,
+                            Response<MessageDeliveryLogResponse> response) {
+                        MessageDeliveryLogResponse messageDeliveryLogResponse = response.body();
+                        assertNotNull(messageDeliveryLogResponse);
+                        assertNotNull(messageDeliveryLogResponse);
+                        assertEquals(200, (int) messageDeliveryLogResponse.status);
+                        assertEquals(1000, (int) messageDeliveryLogResponse.code);
+                        assertNotNull(messageDeliveryLogResponse.data);
+                        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
+                        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+                        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
+                        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
+                        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
+                    }
+
+                    @Override
+                    public void onFailure(Call<MessageDeliveryLogResponse> call, Throwable t) {
+                        // Do nothing
+                    }
+                });
     }
 }

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/RxJavaVotoApiClient.java
@@ -27,6 +27,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -210,6 +211,11 @@ public class RxJavaVotoApiClient extends BaseVotoApiClient {
 
     public Observable<DeleteMessageResponse> deleteMessage(Long id) {
         return mRxJavaVotoService.deleteMessage(id);
+    }
+
+    public Observable<MessageDeliveryLogResponse> getMessageDeliveryLog(Long id,
+            Map<String, String> optionalFields) {
+        return mRxJavaVotoService.getMessageDeliveryLog(id, optionalFields);
     }
 
     public static class Builder extends BaseApiBuilder<Builder, RxJavaVotoApiClient> {

--- a/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/service/RxJavaVotoService.java
+++ b/voto-rxjava/src/main/java/com/addhen/voto/sdk/rxjava/service/RxJavaVotoService.java
@@ -25,8 +25,9 @@ import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
-import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -136,4 +137,8 @@ public interface RxJavaVotoService {
 
     @DELETE(VotoEndpoints.MESSAGES + "/{id}")
     Observable<DeleteMessageResponse> deleteMessage(@Path("id") Long id);
+
+    @GET(Constants.VotoEndpoints.MESSAGES + "/{id}")
+    Observable<MessageDeliveryLogResponse> getMessageDeliveryLog(Long id,
+            @QueryMap Map<String, String> optionalFields);
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/RxJavaVotoApiClientTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/RxJavaVotoApiClientTest.java
@@ -26,6 +26,7 @@ import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -389,5 +390,15 @@ public class RxJavaVotoApiClientTest extends BaseTestCase {
         assertEquals(200, (int) createResponse.status);
         assertEquals(112l, (long) createResponse.data.id);
         assertEquals("Message Created Successfully", createResponse.message);
+    }
+
+    @Test
+    public void shouldSuccessfullyGetMessageDeliveryLogCount() throws IOException {
+        Observable<MessageDeliveryLogResponse> observable = mRxJavaVotoApiClient
+                .getMessageDeliveryLog(1l, null);
+        TestSubscriber<MessageDeliveryLogResponse> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        MessageDeliveryLogResponse messageDeliveryLogResponse = result.getOnNextEvents().get(0);
+        assertMessageDeliveryLogCountResponse(messageDeliveryLogResponse);
     }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/MockRxJavaVotoService.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/MockRxJavaVotoService.java
@@ -26,6 +26,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -166,5 +167,13 @@ public class MockRxJavaVotoService implements RxJavaVotoService {
     public Observable<DeleteMessageResponse> deleteMessage(@Path("id") Long id) {
         final DeleteMessageResponse deleteMessageResponse = mGsonDeserializer.deleteMessage();
         return Observable.just(deleteMessageResponse);
+    }
+
+    @Override
+    public Observable<MessageDeliveryLogResponse> getMessageDeliveryLog(Long id,
+            @QueryMap Map<String, String> optionalFields) {
+        final MessageDeliveryLogResponse messageDeliveryLogResponse = mGsonDeserializer
+                .getMessageDeliveryLogCount();
+        return Observable.just(messageDeliveryLogResponse);
     }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
@@ -24,7 +24,6 @@ import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
-import com.addhen.voto.sdk.model.messages.Message;
 import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
@@ -284,20 +283,7 @@ public class RxJavaVotoServiceTest extends BaseTestCase {
         TestSubscriber<ListMessagesResponse> result = new TestSubscriber<>();
         observable.subscribe(result);
         ListMessagesResponse listMessagesResponse = result.getOnNextEvents().get(0);
-        assertNotNull(listMessagesResponse);
-        assertEquals(200, (int) listMessagesResponse.status);
-        Message message = listMessagesResponse.data.messages.get(0);
-        assertNotNull(message);
-        assertEquals(201712, (long) message.id);
-        assertEquals("Test release 15 Sep 2014 ", message.title);
-        assertEquals(com.addhen.voto.sdk.model.Status.YES, message.hasSms);
-        assertEquals(com.addhen.voto.sdk.model.Status.YES, message.hasVoice);
-        System.out.println("Date: " + message);
-        String created = formatDate("yyyy-MM-dd H:mm:ss", message.created);
-        System.out.println("Created: " + created);
-        assertEquals("2014-09-15 16:20:48", created);
-        String modified = formatDate("yyyy-MM-dd H:mm:ss", message.modified);
-        assertEquals("2014-09-15 16:20:48", modified);
+        assertListMessages(listMessagesResponse);
     }
 
     @Test

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
@@ -333,14 +333,6 @@ public class RxJavaVotoServiceTest extends BaseTestCase {
         TestSubscriber<MessageDeliveryLogResponse> result = new TestSubscriber<>();
         observable.subscribe(result);
         MessageDeliveryLogResponse messageDeliveryLogResponse = result.getOnNextEvents().get(0);
-        assertNotNull(messageDeliveryLogResponse);
-        assertEquals(200, (int) messageDeliveryLogResponse.status);
-        assertEquals(1000, (int) messageDeliveryLogResponse.code);
-        assertNotNull(messageDeliveryLogResponse.data);
-        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
-        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
-        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
-        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
-        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
+        assertMessageDeliveryLogCountResponse(messageDeliveryLogResponse);
     }
 }

--- a/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
+++ b/voto-rxjava/src/test/java/addhen/voto/sdk/rxjava/test/service/RxJavaVotoServiceTest.java
@@ -25,6 +25,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.messages.Message;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -322,5 +323,24 @@ public class RxJavaVotoServiceTest extends BaseTestCase {
         assertNotNull(deleteMessageResponse);
         assertEquals(200, (int) deleteMessageResponse.status);
         assertEquals("Successfully deleted message", deleteMessageResponse.message);
+    }
+
+    @Test
+    public void shouldSuccessfullyGetMessageDeliveryLogCount() throws IOException {
+        assertNotNull(mMockRxJavaVotoService);
+        Observable<MessageDeliveryLogResponse> observable = mMockRxJavaVotoService
+                .getMessageDeliveryLog(1l, null);
+        TestSubscriber<MessageDeliveryLogResponse> result = new TestSubscriber<>();
+        observable.subscribe(result);
+        MessageDeliveryLogResponse messageDeliveryLogResponse = result.getOnNextEvents().get(0);
+        assertNotNull(messageDeliveryLogResponse);
+        assertEquals(200, (int) messageDeliveryLogResponse.status);
+        assertEquals(1000, (int) messageDeliveryLogResponse.code);
+        assertNotNull(messageDeliveryLogResponse.data);
+        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
+        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
+        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
+        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
     }
 }

--- a/voto-sync/src/main/java/com/addhen/voto/sdk/sync/SyncVotoApiClient.java
+++ b/voto-sync/src/main/java/com/addhen/voto/sdk/sync/SyncVotoApiClient.java
@@ -27,6 +27,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -214,6 +215,13 @@ public class SyncVotoApiClient extends BaseVotoApiClient {
 
     public DeleteMessageResponse deleteMessage(Long id) throws IOException {
         Call<DeleteMessageResponse> call = mSyncVotoService.deleteMessage(id);
+        return call.execute().body();
+    }
+
+    public MessageDeliveryLogResponse getMessageDeliveryLog(Long id,
+            @QueryMap Map<String, String> optionalFields) throws IOException {
+        Call<MessageDeliveryLogResponse> call = mSyncVotoService
+                .getMessageDeliveryLog(id, optionalFields);
         return call.execute().body();
     }
 

--- a/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
+++ b/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
@@ -26,6 +26,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -393,5 +394,20 @@ public class SyncVotoApiClientTest extends BaseTestCase {
         assertNotNull(deleteMessageResponse);
         assertEquals(200, (int) deleteMessageResponse.status);
         assertEquals("Successfully deleted message", deleteMessageResponse.message);
+    }
+
+    @Test
+    public void shouldSuccessfullyGetMessageDeliveryLogCount() throws IOException {
+        MessageDeliveryLogResponse messageDeliveryLogResponse = mSyncVotoApiClient
+                .getMessageDeliveryLog(1l, null);
+        assertNotNull(messageDeliveryLogResponse);
+        assertEquals(200, (int) messageDeliveryLogResponse.status);
+        assertEquals(1000, (int) messageDeliveryLogResponse.code);
+        assertNotNull(messageDeliveryLogResponse.data);
+        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
+        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
+        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
+        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
     }
 }

--- a/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
+++ b/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
@@ -400,11 +400,6 @@ public class SyncVotoApiClientTest extends BaseTestCase {
     public void shouldSuccessfullyGetMessageDeliveryLogCount() throws IOException {
         MessageDeliveryLogResponse messageDeliveryLogResponse = mSyncVotoApiClient
                 .getMessageDeliveryLog(1l, null);
-        assertNotNull(messageDeliveryLogResponse);
-        assertEquals(200, (int) messageDeliveryLogResponse.status);
-        assertEquals(1000, (int) messageDeliveryLogResponse.code);
-        assertNotNull(messageDeliveryLogResponse.data);
-        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
-        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+        assertMessageDeliveryLogCountResponse(messageDeliveryLogResponse);
     }
 }

--- a/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
+++ b/voto-sync/src/test/java/com/addhen/voto/sdk/sync/test/SyncVotoApiClientTest.java
@@ -406,8 +406,5 @@ public class SyncVotoApiClientTest extends BaseTestCase {
         assertNotNull(messageDeliveryLogResponse.data);
         assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
         assertEquals(2, (int) messageDeliveryLogResponse.data.count);
-        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
-        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
-        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
     }
 }

--- a/voto/src/main/java/com/addhen/voto/sdk/model/BaseResponse.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/BaseResponse.java
@@ -24,6 +24,18 @@ package com.addhen.voto.sdk.model;
  */
 public abstract class BaseResponse {
 
+    /** The code from the API response **/
+    public Integer code;
+
+    /** More info **/
+    public String moreInfo;
+
+    /** The to fetch the URL **/
+    public String url;
+
+    /** The pagination property **/
+    public Pagination pagination;
+
     /** The status code of the request **/
     public Integer status;
 

--- a/voto/src/main/java/com/addhen/voto/sdk/model/deliverylogs/DeliveryLog.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/deliverylogs/DeliveryLog.java
@@ -9,14 +9,19 @@ import java.util.Date;
  */
 public class DeliveryLog {
 
+    /** The message id */
     public Long messageId;
 
+    /** Status of the delivery report */
     public DeliveryStatus filterDeliveryStatus;
 
+    /** The filter after date */
     public Date filterAfterDate;
 
+    /** The filter by before date */
     public Date filterBeforeDate;
 
+    /** Number of delivery reports */
     public Integer count;
 
     @Override
@@ -30,47 +35,60 @@ public class DeliveryLog {
                 + '}';
     }
 
+    @SuppressWarnings("Lint.Missing a Javadoc comment")
     public enum DeliveryStatus {
-
+        /** Queued **/
         @SerializedName("1")
         Queued,
-
+        /** Ringing **/
         @SerializedName("2")
         Ringing,
 
+        /** In progress **/
         @SerializedName("3")
         IN_PROGRESS,
 
+        /** Waiting to try again **/
         @SerializedName("4")
         WAITING_TO_TRY,
 
+        /** Failed with no answer **/
         @SerializedName("5")
         FAILED_NO_ANSWER,
 
+        /** Completely finished **/
         @SerializedName("6")
         FINISHED_COMPLETE,
 
+        /** Incompletely finished **/
         @SerializedName("7")
         FINISHED_INCOMPLETE,
 
+        /** Failed with no voto credit **/
         @SerializedName("8")
         FAILED_NO_VOTO_CREDIT,
 
+        /** Failed with no network **/
         @SerializedName("9")
         FAILED_NO_NETWORK,
 
+        /** cancelled **/
         @SerializedName("10")
         FAILED_CANCELLED,
 
+        /** Sent **/
         @SerializedName("11")
         SENT,
 
+        /** Voicemail finished **/
         @SerializedName("12")
         FINISHED_VOICEMAIL,
 
+        /** Voicemail failed **/
         @SerializedName("13")
         FAILED_VOICEMAIL,
 
+        /** Voicemail voice **/
         @SerializedName("14")
         FAILED_VOICE;
     }

--- a/voto/src/main/java/com/addhen/voto/sdk/model/deliverylogs/DeliveryLog.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/deliverylogs/DeliveryLog.java
@@ -24,6 +24,14 @@ public class DeliveryLog {
     /** Number of delivery reports */
     public Integer count;
 
+    public DeliveryLog(Long messageId, DeliveryStatus filterDeliveryStatus, Date filterAfterDate,
+            Date filterBeforeDate) {
+        this.messageId = messageId;
+        this.filterDeliveryStatus = filterDeliveryStatus;
+        this.filterAfterDate = filterAfterDate;
+        this.filterBeforeDate = filterBeforeDate;
+    }
+
     @Override
     public String toString() {
         return "DeliveryLog{"

--- a/voto/src/main/java/com/addhen/voto/sdk/model/deliverylogs/DeliveryLog.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/deliverylogs/DeliveryLog.java
@@ -1,0 +1,77 @@
+package com.addhen.voto.sdk.model.deliverylogs;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+
+/**
+ * @author Henry Addo
+ */
+public class DeliveryLog {
+
+    public Long messageId;
+
+    public DeliveryStatus filterDeliveryStatus;
+
+    public Date filterAfterDate;
+
+    public Date filterBeforeDate;
+
+    public Integer count;
+
+    @Override
+    public String toString() {
+        return "DeliveryLog{"
+                + "messageId=" + messageId
+                + ", filterDeliveryStatus=" + filterDeliveryStatus
+                + ", filterAfterDate=" + filterAfterDate
+                + ", filterBeforeDate=" + filterBeforeDate
+                + ", count=" + count
+                + '}';
+    }
+
+    public enum DeliveryStatus {
+
+        @SerializedName("1")
+        Queued,
+
+        @SerializedName("2")
+        Ringing,
+
+        @SerializedName("3")
+        IN_PROGRESS,
+
+        @SerializedName("4")
+        WAITING_TO_TRY,
+
+        @SerializedName("5")
+        FAILED_NO_ANSWER,
+
+        @SerializedName("6")
+        FINISHED_COMPLETE,
+
+        @SerializedName("7")
+        FINISHED_INCOMPLETE,
+
+        @SerializedName("8")
+        FAILED_NO_VOTO_CREDIT,
+
+        @SerializedName("9")
+        FAILED_NO_NETWORK,
+
+        @SerializedName("10")
+        FAILED_CANCELLED,
+
+        @SerializedName("11")
+        SENT,
+
+        @SerializedName("12")
+        FINISHED_VOICEMAIL,
+
+        @SerializedName("13")
+        FAILED_VOICEMAIL,
+
+        @SerializedName("14")
+        FAILED_VOICE;
+    }
+}

--- a/voto/src/main/java/com/addhen/voto/sdk/model/messages/ListMessagesResponse.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/messages/ListMessagesResponse.java
@@ -17,7 +17,6 @@
 package com.addhen.voto.sdk.model.messages;
 
 import com.addhen.voto.sdk.model.BaseResponse;
-import com.addhen.voto.sdk.model.Pagination;
 
 import java.util.List;
 
@@ -27,18 +26,6 @@ import java.util.List;
  * @author Henry Addo
  */
 public class ListMessagesResponse extends BaseResponse {
-
-    /** The code from the API response **/
-    public Integer code;
-
-    /** More info **/
-    public String moreInfo;
-
-    /** The to fetch the URL **/
-    public String url;
-
-    /** The pagination property **/
-    public Pagination pagination;
 
     /** The returned subscribers list **/
     public Data data;

--- a/voto/src/main/java/com/addhen/voto/sdk/model/messages/MessageDeliveryLogResponse.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/messages/MessageDeliveryLogResponse.java
@@ -1,0 +1,13 @@
+package com.addhen.voto.sdk.model.messages;
+
+import com.addhen.voto.sdk.model.BaseResponse;
+import com.addhen.voto.sdk.model.deliverylogs.DeliveryLog;
+
+/**
+ * @author Henry Addo
+ */
+public class MessageDeliveryLogResponse extends BaseResponse {
+
+    /** The returned subscribers list **/
+    public DeliveryLog data;
+}

--- a/voto/src/main/java/com/addhen/voto/sdk/model/subscribers/ListSubscribersResponse.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/model/subscribers/ListSubscribersResponse.java
@@ -17,7 +17,6 @@
 package com.addhen.voto.sdk.model.subscribers;
 
 import com.addhen.voto.sdk.model.BaseResponse;
-import com.addhen.voto.sdk.model.Pagination;
 
 import java.util.List;
 
@@ -27,18 +26,6 @@ import java.util.List;
  * @author Henry Addo
  */
 public class ListSubscribersResponse extends BaseResponse {
-
-    /** The code from the API response **/
-    public Integer code;
-
-    /** More info **/
-    public String moreInfo;
-
-    /** The to fetch the URL **/
-    public String url;
-
-    /** The pagination property **/
-    public Pagination pagination;
 
     /** The returned subscribers list **/
     public Data data;

--- a/voto/src/main/java/com/addhen/voto/sdk/service/VotoService.java
+++ b/voto/src/main/java/com/addhen/voto/sdk/service/VotoService.java
@@ -25,8 +25,9 @@ import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
-import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -129,4 +130,8 @@ public interface VotoService {
 
     @DELETE(Constants.VotoEndpoints.MESSAGES + "/{id}")
     Call<DeleteMessageResponse> deleteMessage(@Path("id") Long id);
+
+    @GET(Constants.VotoEndpoints.MESSAGES + "/{id}")
+    Call<MessageDeliveryLogResponse> getMessageDeliveryLog(Long id,
+            @QueryMap Map<String, String> optionalFields);
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/BaseTestCase.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/BaseTestCase.java
@@ -21,6 +21,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import com.addhen.voto.sdk.DateDeserializer;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.Message;
 import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.service.VotoService;
 import com.addhen.voto.sdk.test.service.MockVotoService;
@@ -100,5 +102,22 @@ public abstract class BaseTestCase {
         assertNotNull(messageDeliveryLogResponse.data);
         assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
         assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+    }
+
+    protected void assertListMessages(ListMessagesResponse listMessagesResponse) {
+        assertNotNull(listMessagesResponse);
+        assertEquals(200, (int) listMessagesResponse.status);
+        Message message = listMessagesResponse.data.messages.get(0);
+        assertNotNull(message);
+        assertEquals(201712, (long) message.id);
+        assertEquals("Test release 15 Sep 2014 ", message.title);
+        assertEquals(com.addhen.voto.sdk.model.Status.YES, message.hasSms);
+        assertEquals(com.addhen.voto.sdk.model.Status.YES, message.hasVoice);
+        System.out.println("Date: " + message);
+        String created = formatDate("yyyy-MM-dd H:mm:ss", message.created);
+        System.out.println("Created: " + created);
+        assertEquals("2014-09-15 16:20:48", created);
+        String modified = formatDate("yyyy-MM-dd H:mm:ss", message.modified);
+        assertEquals("2014-09-15 16:20:48", modified);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/BaseTestCase.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/BaseTestCase.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import com.addhen.voto.sdk.DateDeserializer;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.service.VotoService;
 import com.addhen.voto.sdk.test.service.MockVotoService;
 
@@ -37,6 +38,9 @@ import retrofit2.Retrofit;
 import retrofit2.mock.BehaviorDelegate;
 import retrofit2.mock.MockRetrofit;
 import retrofit2.mock.NetworkBehavior;
+
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 /**
  * All unit test cases have to inherit from this. This is to make it easier to
@@ -86,5 +90,15 @@ public abstract class BaseTestCase {
         BehaviorDelegate<VotoService> votoServiceBehaviorDelegate = mockRetrofit
                 .create(VotoService.class);
         return new MockVotoService(votoServiceBehaviorDelegate, gsonDeserializer);
+    }
+
+    protected void assertMessageDeliveryLogCountResponse(
+            MessageDeliveryLogResponse messageDeliveryLogResponse) {
+        assertNotNull(messageDeliveryLogResponse);
+        assertEquals(200, (int) messageDeliveryLogResponse.status);
+        assertEquals(1000, (int) messageDeliveryLogResponse.code);
+        assertNotNull(messageDeliveryLogResponse.data);
+        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
+        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/BaseTestCase.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/BaseTestCase.java
@@ -31,7 +31,7 @@ import org.junit.runners.JUnit4;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Random;
-import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import retrofit2.Retrofit;
 import retrofit2.mock.BehaviorDelegate;
@@ -77,6 +77,7 @@ public abstract class BaseTestCase {
         // Create a MockRetrofit object with a NetworkBehavior which manages the fake behavior of calls.
         NetworkBehavior behavior = NetworkBehavior.create(new Random(2847));
         MockRetrofit mockRetrofit = new MockRetrofit.Builder(retrofit)
+                .backgroundExecutor(Executors.newSingleThreadExecutor())
                 .networkBehavior(behavior)
                 .build();
 
@@ -85,13 +86,5 @@ public abstract class BaseTestCase {
         BehaviorDelegate<VotoService> votoServiceBehaviorDelegate = mockRetrofit
                 .create(VotoService.class);
         return new MockVotoService(votoServiceBehaviorDelegate, gsonDeserializer);
-    }
-
-    private static class Synchronous implements Executor {
-
-        @Override
-        public void execute(Runnable command) {
-            command.run();
-        }
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/GsonDeserializer.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/GsonDeserializer.java
@@ -25,6 +25,7 @@ import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
 import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -200,5 +201,15 @@ public final class GsonDeserializer {
             e.printStackTrace();
         }
         return mGson.fromJson(responseJson, DeleteMessageResponse.class);
+    }
+
+    public MessageDeliveryLogResponse getMessageDeliveryLogCount() {
+        String responseJson = null;
+        try {
+            responseJson = getResource("json/message/message_delivery_log_count.json");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return mGson.fromJson(responseJson, MessageDeliveryLogResponse.class);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/model/deliverylogs/DeliveryLogTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/model/deliverylogs/DeliveryLogTest.java
@@ -1,0 +1,65 @@
+package com.addhen.voto.sdk.test.model.deliverylogs;
+
+import com.addhen.voto.sdk.model.deliverylogs.DeliveryLog;
+import com.addhen.voto.sdk.test.BaseTestCase;
+import com.addhen.voto.sdk.util.StringUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Henry Addo
+ */
+public class DeliveryLogTest extends BaseTestCase {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd hh:mm:ss";
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void shouldCreateDeliveryLogObject() {
+        final DeliveryLog deliveryLog = initDeliveryLog();
+        assertNotNull(deliveryLog);
+        assertEquals(1l, (long) deliveryLog.messageId);
+        assertEquals(DeliveryLog.DeliveryStatus.Queued, deliveryLog.filterDeliveryStatus);
+        String created = formatDate(DATE_FORMAT, deliveryLog.filterBeforeDate);
+        assertEquals("2015-08-24 05:28:48", created);
+        String modified = formatDate(DATE_FORMAT, deliveryLog.filterAfterDate);
+        assertEquals("2015-10-30 09:22:15", modified);
+    }
+
+    @Test
+    public void shouldTestMessageToString() {
+        final DeliveryLog deliveryLog = initDeliveryLog();
+        final String toString = deliveryLog.toString();
+        assertFalse(StringUtils.isEmpty(deliveryLog.toString()));
+    }
+
+    private DeliveryLog initDeliveryLog() {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DATE_FORMAT);
+        Date created = null;
+        try {
+            created = simpleDateFormat.parse("2015-08-24 05:28:48");
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        Date modified = null;
+        try {
+            modified = simpleDateFormat.parse("2015-10-30 09:22:15");
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+        return new DeliveryLog(1L, DeliveryLog.DeliveryStatus.Queued, modified, created);
+    }
+}

--- a/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/DeleteMessageResponseTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/DeleteMessageResponseTest.java
@@ -34,7 +34,6 @@ public class DeleteMessageResponseTest extends BaseTestCase {
     @Test
     public void shouldTestToStringToMakeSureItsNotEmpty() throws Exception {
         final String toString = mDeleteMessageResponse.toString();
-        System.out.print(toString);
         assertEquals(
                 "BaseResponse{status=200, message='Successfully deleted message'}",
                 toString

--- a/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/DeleteMessageResponseTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/DeleteMessageResponseTest.java
@@ -1,0 +1,43 @@
+package com.addhen.voto.sdk.test.model.messages;
+
+import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
+import com.addhen.voto.sdk.test.BaseTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Henry Addo
+ */
+public class DeleteMessageResponseTest extends BaseTestCase {
+
+    private DeleteMessageResponse mDeleteMessageResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        mDeleteMessageResponse = mGsonDeserializer.deleteMessage();
+    }
+
+    @Test
+    public void shouldSuccessfullyDeserializeDeleteMessageResponseTest() throws IOException {
+        assertNotNull(mDeleteMessageResponse);
+        assertEquals(200, (int) mDeleteMessageResponse.status);
+        assertEquals("Successfully deleted message", mDeleteMessageResponse.message);
+    }
+
+    @Test
+    public void shouldTestToStringToMakeSureItsNotEmpty() throws Exception {
+        final String toString = mDeleteMessageResponse.toString();
+        System.out.print(toString);
+        assertEquals(
+                "BaseResponse{status=200, message='Successfully deleted message'}",
+                toString
+        );
+    }
+}

--- a/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/ListMessagesResponseTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/ListMessagesResponseTest.java
@@ -1,0 +1,36 @@
+package com.addhen.voto.sdk.test.model.messages;
+
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.test.BaseTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Henry Addo
+ */
+public class ListMessagesResponseTest extends BaseTestCase {
+
+    private ListMessagesResponse mListMessagesResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        mListMessagesResponse = mGsonDeserializer.listMessages();
+    }
+
+    @Test
+    public void shouldSuccessfullyDeserializeDeleteMessageResponseTest() throws IOException {
+        assertListMessages(mListMessagesResponse);
+    }
+
+    @Test
+    public void shouldTestToStringToMakeSureItsNotEmpty() throws Exception {
+        final String toString = mListMessagesResponse.toString();
+        assertNotNull(toString);
+    }
+}

--- a/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/MessageDeliveryLogResponseTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/model/messages/MessageDeliveryLogResponseTest.java
@@ -1,0 +1,37 @@
+package com.addhen.voto.sdk.test.model.messages;
+
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
+import com.addhen.voto.sdk.test.BaseTestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Henry Addo
+ */
+public class MessageDeliveryLogResponseTest extends BaseTestCase {
+
+    private MessageDeliveryLogResponse mMessageDeliveryLogResponse;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        mMessageDeliveryLogResponse = mGsonDeserializer.getMessageDeliveryLogCount();
+        assertNotNull(mMessageDeliveryLogResponse);
+    }
+
+    @Test
+    public void shouldSuccessfullyDeserializeDeleteMessageResponseTest() throws IOException {
+        assertMessageDeliveryLogCountResponse(mMessageDeliveryLogResponse);
+    }
+
+    @Test
+    public void shouldTestToStringToMakeSureItsNotEmpty() throws Exception {
+        final String toString = mMessageDeliveryLogResponse.toString();
+        assertNotNull(toString);
+    }
+}

--- a/voto/src/test/java/com/addhen/voto/sdk/test/model/subscribers/CreateSubscriberResponseTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/model/subscribers/CreateSubscriberResponseTest.java
@@ -42,7 +42,6 @@ public class CreateSubscriberResponseTest extends BaseTestCase {
         final CreateSubscriberResponse createSubscriberResponse = mGsonDeserializer
                 .deserializeCreateSubscriberResponse();
         assertNotNull(createSubscriberResponse);
-        assertNotNull(createSubscriberResponse);
         assertNotNull(createSubscriberResponse.data);
         assertEquals(430l, (long) createSubscriberResponse.data.id);
     }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/MockVotoService.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/MockVotoService.java
@@ -24,8 +24,9 @@ import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
 import com.addhen.voto.sdk.model.audio.UploadAudioFileResponse;
-import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.messages.DeleteMessageResponse;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -187,5 +188,14 @@ public class MockVotoService implements VotoService {
     public Call<DeleteMessageResponse> deleteMessage(@Path("id") Long id) {
         final DeleteMessageResponse messageResponse = mGsonDeserializer.deleteMessage();
         return mDelegate.returningResponse(messageResponse).deleteMessage(id);
+    }
+
+    @Override
+    public Call<MessageDeliveryLogResponse> getMessageDeliveryLog(Long id,
+            @QueryMap Map<String, String> optionalFields) {
+        final MessageDeliveryLogResponse messageDeliveryLogResponse = mGsonDeserializer
+                .getMessageDeliveryLogCount();
+        return mDelegate.returningResponse(messageDeliveryLogResponse)
+                .getMessageDeliveryLog(id, optionalFields);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
@@ -21,6 +21,7 @@ import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
+import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
 import com.addhen.voto.sdk.model.subscribers.DeleteSubscriberResponse;
@@ -185,5 +186,21 @@ public class VotoServiceTest extends BaseTestCase {
         ResponseBody responseBody = call.execute().body();
         assertNotNull(responseBody);
         assertEquals("AudioFile", responseBody.string());
+    }
+
+    @Test
+    public void shouldSuccessfullyFetchMessageDeliveryCount() throws IOException {
+        assertNotNull(mMockVotoService);
+        Call<MessageDeliveryLogResponse> call = mMockVotoService.getMessageDeliveryLog(1l, null);
+        MessageDeliveryLogResponse messageDeliveryLogResponse = call.execute().body();
+        assertNotNull(messageDeliveryLogResponse);
+        assertEquals(200, (int) messageDeliveryLogResponse.status);
+        assertEquals(1000, (int) messageDeliveryLogResponse.code);
+        assertNotNull(messageDeliveryLogResponse.data);
+        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
+        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
+        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
+        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
+        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
@@ -21,6 +21,7 @@ import com.addhen.voto.sdk.model.audio.AudioFileDetailsResponse;
 import com.addhen.voto.sdk.model.audio.AudioFileFormat;
 import com.addhen.voto.sdk.model.audio.DeleteAudioFileResponse;
 import com.addhen.voto.sdk.model.audio.ListAudioFilesResponse;
+import com.addhen.voto.sdk.model.messages.ListMessagesResponse;
 import com.addhen.voto.sdk.model.messages.MessageDeliveryLogResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateBulkSubscribersResponse;
 import com.addhen.voto.sdk.model.subscribers.CreateSubscriberResponse;
@@ -54,11 +55,11 @@ public class VotoServiceTest extends BaseTestCase {
     public void setUp() throws Exception {
         super.setUp();
         mMockVotoService = getMockVotoService();
+        assertNotNull(mMockVotoService);
     }
 
     @Test
     public void shouldSuccessfullyCreateSubscriber() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<CreateSubscriberResponse> call = mMockVotoService
                 .createSubscriber("", null);
         CreateSubscriberResponse createSubscriberResponse = call.execute().body();
@@ -69,7 +70,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyCreateBulkSubscribers() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<CreateBulkSubscribersResponse> call = mMockVotoService
                 .createBulkSubscribers("", null, null);
         CreateBulkSubscribersResponse response = call.execute().body();
@@ -82,7 +82,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyDeleteSubscriber() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<DeleteSubscriberResponse> call = mMockVotoService.deleteSubscriber(1l);
         DeleteSubscriberResponse response = call.execute().body();
         assertNotNull(response);
@@ -92,7 +91,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyListSubscribers() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<ListSubscribersResponse> call = mMockVotoService.listSubscribers(10);
         ListSubscribersResponse response = call.execute().body();
         assertNotNull(response);
@@ -130,7 +128,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyListAudioFiles() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<ListAudioFilesResponse> call = mMockVotoService.listAudioFiles();
         ListAudioFilesResponse listAudioFilesResponse = call.execute().body();
 
@@ -152,7 +149,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyDeleteAudioFIle() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<DeleteAudioFileResponse> call = mMockVotoService.deleteAudioFile(1l);
         DeleteAudioFileResponse response = call.execute().body();
         assertNotNull(response);
@@ -162,7 +158,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyListAudioFileDetails() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<AudioFileDetailsResponse> call = mMockVotoService.listAudioFileDetails(1l);
         AudioFileDetailsResponse response = call.execute().body();
         assertNotNull(response);
@@ -181,7 +176,6 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyDownloadAudioFile() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<ResponseBody> call = mMockVotoService.downloadAudioFile(1l, AudioFileFormat.ORIGINAL);
         ResponseBody responseBody = call.execute().body();
         assertNotNull(responseBody);
@@ -190,9 +184,15 @@ public class VotoServiceTest extends BaseTestCase {
 
     @Test
     public void shouldSuccessfullyFetchMessageDeliveryCount() throws IOException {
-        assertNotNull(mMockVotoService);
         Call<MessageDeliveryLogResponse> call = mMockVotoService.getMessageDeliveryLog(1l, null);
         MessageDeliveryLogResponse messageDeliveryLogResponse = call.execute().body();
         assertMessageDeliveryLogCountResponse(messageDeliveryLogResponse);
+    }
+
+    @Test
+    public void shouldSuccessfullyListMessages() throws IOException {
+        Call<ListMessagesResponse> call = mMockVotoService.listMessages();
+        ListMessagesResponse listMessagesResponse = call.execute().body();
+        assertListMessages(listMessagesResponse);
     }
 }

--- a/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
+++ b/voto/src/test/java/com/addhen/voto/sdk/test/service/VotoServiceTest.java
@@ -193,14 +193,6 @@ public class VotoServiceTest extends BaseTestCase {
         assertNotNull(mMockVotoService);
         Call<MessageDeliveryLogResponse> call = mMockVotoService.getMessageDeliveryLog(1l, null);
         MessageDeliveryLogResponse messageDeliveryLogResponse = call.execute().body();
-        assertNotNull(messageDeliveryLogResponse);
-        assertEquals(200, (int) messageDeliveryLogResponse.status);
-        assertEquals(1000, (int) messageDeliveryLogResponse.code);
-        assertNotNull(messageDeliveryLogResponse.data);
-        assertEquals(201712, (long) messageDeliveryLogResponse.data.messageId);
-        assertEquals(2, (int) messageDeliveryLogResponse.data.count);
-        assertNull(messageDeliveryLogResponse.data.filterAfterDate);
-        assertNull(messageDeliveryLogResponse.data.filterBeforeDate);
-        assertNull(messageDeliveryLogResponse.data.filterDeliveryStatus);
+        assertMessageDeliveryLogCountResponse(messageDeliveryLogResponse);
     }
 }

--- a/voto/src/test/resources/json/message/message_delivery_log_count.json
+++ b/voto/src/test/resources/json/message/message_delivery_log_count.json
@@ -3,6 +3,8 @@
   "code": 1000,
   "data": {
     "message_id": "201712",
+    "filter_delivery_status": "6",
+    "filter_after_date": "2014-02-15",
     "count": 2
   },
   "message": "Fetched Message Counts: 2 times accessed.",

--- a/voto/src/test/resources/json/message/message_delivery_log_count.json
+++ b/voto/src/test/resources/json/message/message_delivery_log_count.json
@@ -1,0 +1,12 @@
+{
+  "status": 200,
+  "code": 1000,
+  "data": {
+    "message_id": "201712",
+    "count": 2
+  },
+  "message": "Fetched Message Counts: 2 times accessed.",
+  "more_info": "",
+  "pagination": null,
+  "url": "https://go.votomobile.org/api/v1/messages/201712/counts"
+}


### PR DESCRIPTION
Fixes #30  

This `PR` makes the following changes:
- Adds a `DeliveryLog` model 
- Implements message delivery log endpoint.
- Add test for the endpoint implementation.
- Refactor all async test cases so actual assertions occurs. They were skipped because of the async operations.
